### PR TITLE
Basic swagger setup. Enumeration values gives null-pointer exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ For live reloading, subtsitute `jetty:start` with `~;jetty:stop;jetty:start`.
 
 GraphQL API is then available on [http://localhost:8080/](http://localhost:8080/).
 
+## API documentation
+We have generated swagger documentation for our API. The swagger documentation is availble at [http://localhost:8080/docs](http://localhost:8080/docs). Swagger-ui enables you to view the documentation as well as live testing. Head over to [https://github.com/swagger-api/swagger-ui/](https://github.com/swagger-api/swagger-ui/).
+
+It is to be noted that since we currently support v1.2 of the swagger specification, only swagger-ui of version v2.x is supported.
+
 ## Testing
 ```sh
 $ ./sbt

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ libraryDependencies ++= Seq(
   "org.scalatra" %% "scalatra" % ScalatraVersion,
   "org.scalatra" %% "scalatra-scalate" % ScalatraVersion,
   "org.scalatra" %% "scalatra-json" % ScalatraVersion,
+  "org.scalatra" %% "scalatra-swagger" % "2.5.0",
   "org.json4s"   %% "json4s-jackson" % Json4sVersion,
   "org.json4s"   %% "json4s-ext" % Json4sVersion,
   "org.scalactic" %% "scalactic" % ScalaTestVersion,

--- a/src/main/resources/db/migration/V001__Initial_Tables.sql
+++ b/src/main/resources/db/migration/V001__Initial_Tables.sql
@@ -8,6 +8,9 @@ CREATE TABLE users
   facebook_id INT NOT NULL
 );
 
+ALTER TABLE users
+  ADD CONSTRAINT ck_gender CHECK (gender IN ('F', 'M', 'O'));
+
 CREATE TABLE routes
 (
   route_id SERIAL PRIMARY KEY,
@@ -35,6 +38,9 @@ CREATE TABLE crawl_participants
   user_id INT REFERENCES users(user_id),
   status CHAR(1) NOT NULL
 );
+
+ALTER TABLE crawl_participants
+  ADD CONSTRAINT ck_status CHECK (status IN ('A', 'D', 'M'));
 
 CREATE TABLE stops
 (

--- a/src/main/resources/db/migration/V001__Initial_Tables.sql
+++ b/src/main/resources/db/migration/V001__Initial_Tables.sql
@@ -8,9 +8,6 @@ CREATE TABLE users
   facebook_id INT NOT NULL
 );
 
-ALTER TABLE users
-  ADD CONSTRAINT ck_gender CHECK (gender IN ('F', 'M', 'O'));
-
 CREATE TABLE routes
 (
   route_id SERIAL PRIMARY KEY,
@@ -38,9 +35,6 @@ CREATE TABLE crawl_participants
   user_id INT REFERENCES users(user_id),
   status CHAR(1) NOT NULL
 );
-
-ALTER TABLE crawl_participants
-  ADD CONSTRAINT ck_status CHECK (status IN ('A', 'D', 'M'));
 
 CREATE TABLE stops
 (

--- a/src/main/resources/db/migration/V002__Constraints.sql
+++ b/src/main/resources/db/migration/V002__Constraints.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+  ADD CONSTRAINT ck_gender CHECK (gender IN ('F', 'M', 'O'));
+
+ALTER TABLE crawl_participants
+  ADD CONSTRAINT ck_status CHECK (status IN ('A', 'D', 'M'));

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -4,15 +4,19 @@ import akka.actor.ActorSystem
 import com.typesafe.scalalogging.LazyLogging
 import io.pubcrawler.stout.controllers.{CrawlController, ProfileController}
 import io.pubcrawler.stout.db.DbConnection
+import io.pubcrawler.stout.swagger.{ApiDocs, StoutSwagger}
 import org.scalatra._
 
 class ScalatraBootstrap extends LifeCycle with LazyLogging with DbConnection {
   val system = ActorSystem()
 
+  implicit val swagger = new StoutSwagger
+
   override def init(context: ServletContext) {
 //    context mount(new StoutController, "/*")
-    context.mount(new ProfileController(db), "/profile/*")
-    context.mount(new CrawlController(db), "/crawl/*")
+    context.mount(new ProfileController(db, swagger), "/profile/*")
+    context.mount(new CrawlController(db, swagger), "/crawl/*")
+    context.mount(new ApiDocs(), "/docs")
     logger info "Stout started"
   }
 

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -2,9 +2,8 @@ import javax.servlet.ServletContext
 
 import akka.actor.ActorSystem
 import com.typesafe.scalalogging.LazyLogging
-import io.pubcrawler.stout.controllers.{CrawlController, ProfileController}
+import io.pubcrawler.stout.controllers.{CrawlController, ProfileController, StoutSwagger, SwaggerController}
 import io.pubcrawler.stout.db.DbConnection
-import io.pubcrawler.stout.swagger.{ApiDocs, StoutSwagger}
 import org.scalatra._
 
 class ScalatraBootstrap extends LifeCycle with LazyLogging with DbConnection {
@@ -13,10 +12,10 @@ class ScalatraBootstrap extends LifeCycle with LazyLogging with DbConnection {
   implicit val swagger = new StoutSwagger
 
   override def init(context: ServletContext) {
-//    context mount(new StoutController, "/*")
-    context.mount(new ProfileController(db, swagger), "/profile/*")
-    context.mount(new CrawlController(db, swagger), "/crawl/*")
-    context.mount(new ApiDocs(), "/docs")
+    context.mount(new ProfileController, "/profile/*")
+    context.mount(new CrawlController, "/crawl/*")
+    context.mount(new SwaggerController, "/docs")
+
     logger info "Stout started"
   }
 

--- a/src/main/scala/io/pubcrawler/stout/controllers/CrawlController.scala
+++ b/src/main/scala/io/pubcrawler/stout/controllers/CrawlController.scala
@@ -1,11 +1,11 @@
 package io.pubcrawler.stout.controllers
 
 import akka.util.Timeout
-import io.pubcrawler.stout.db.{Crawl, Status, TableDefinitions}
+import io.pubcrawler.stout.db.{Crawl, TableDefinitions}
 import io.pubcrawler.stout.models.{Participant, Result}
 import io.pubcrawler.stout.util.{JsonFormat, UtilAsync}
 import org.scalatra.json.JacksonJsonSupport
-import org.scalatra.swagger.{Api, Swagger, SwaggerEngine, SwaggerSupport}
+import org.scalatra.swagger.{Swagger, SwaggerSupport}
 import org.scalatra.{FutureSupport, ScalatraServlet}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -14,9 +14,12 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 
-class CrawlController(db: Database, implicit val swagger: Swagger) extends ScalatraServlet
-  with JacksonJsonSupport with FutureSupport with CrawlControllerSwaggerDef with TableDefinitions with JsonFormat with UtilAsync {
+class CrawlController(implicit val db: Database, implicit val swagger: Swagger) extends ScalatraServlet
+  with JacksonJsonSupport with FutureSupport with TableDefinitions with JsonFormat with UtilAsync with SwaggerSupport {
+
   protected implicit val timeout = new Timeout(2.seconds)
+
+  override protected def applicationDescription: String = "Stout Crawl API"
 
   private val ifNotFoundMessage: String = "crawl not found"
 
@@ -24,10 +27,18 @@ class CrawlController(db: Database, implicit val swagger: Swagger) extends Scala
     contentType = formats("json")
   }
 
+  val getCrawl = apiOperation[Crawl]("getCrawl")
+    .parameters(pathParam[Int]("crawlId").description("id for crawl"))
+    .summary("gets a crawl by given id")
+
   get("/:crawlId", operation(getCrawl)) {
     val result: Future[Option[Crawl]] = db.run(crawls.filter(_.id === params("crawlId").toInt).result.headOption)
     resultOption(result, ifNotFoundMessage)
   }
+
+  val getCrawlParticipants = apiOperation[Participant]("getParticipants")
+    .parameters(pathParam[Int]("crawlId").description("id for crawl"))
+    .summary("gets all participants of a crawl")
 
   get("/:crawlId/participants", operation(getCrawlParticipants)) {
     val query = for {
@@ -36,25 +47,13 @@ class CrawlController(db: Database, implicit val swagger: Swagger) extends Scala
       u <- users if p.userId === u.id
     } yield (u.username, p.status, p.userId)
 
-    val resultList: Future[Seq[(String, Status.Status, Int)]] = db.run(query.result)
+    val resultList: Future[Seq[(String, Char, Int)]] = db.run(query.result)
     val result = resultList.map(_.map(Participant tupled _))
     resultSeq(result)
   }
 
   notFound {
-    Result(404, "not valid endpoint")
+    Result(404, "not a valid endpoint")
   }
 
-}
-
-trait CrawlControllerSwaggerDef extends SwaggerSupport {
-  protected val applicationDescription = "Crawl RESTful API"
-
-  val getCrawl = apiOperation[Crawl]("getCrawl")
-    .parameter(queryParam[Int]("crawlId").description("id for crawl"))
-    .summary("gets a crawl by given id")
-
-  val getCrawlParticipants = apiOperation[Participant]("getParticipants").parameter(queryParam[Int]("crawlId")
-    .description("id for crawl"))
-    .summary("gets all participants of a crawl")
 }

--- a/src/main/scala/io/pubcrawler/stout/controllers/CrawlController.scala
+++ b/src/main/scala/io/pubcrawler/stout/controllers/CrawlController.scala
@@ -5,6 +5,7 @@ import io.pubcrawler.stout.db.{Crawl, Status, TableDefinitions}
 import io.pubcrawler.stout.models.{Participant, Result}
 import io.pubcrawler.stout.util.{JsonFormat, UtilAsync}
 import org.scalatra.json.JacksonJsonSupport
+import org.scalatra.swagger.{Api, Swagger, SwaggerEngine, SwaggerSupport}
 import org.scalatra.{FutureSupport, ScalatraServlet}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -13,8 +14,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 
-class CrawlController(db: Database) extends ScalatraServlet
-  with JacksonJsonSupport with FutureSupport with TableDefinitions with JsonFormat with UtilAsync {
+class CrawlController(db: Database, implicit val swagger: Swagger) extends ScalatraServlet
+  with JacksonJsonSupport with FutureSupport with CrawlControllerSwaggerDef with TableDefinitions with JsonFormat with UtilAsync {
   protected implicit val timeout = new Timeout(2.seconds)
 
   private val ifNotFoundMessage: String = "crawl not found"
@@ -23,12 +24,12 @@ class CrawlController(db: Database) extends ScalatraServlet
     contentType = formats("json")
   }
 
-  get("/:crawlId") {
+  get("/:crawlId", operation(getCrawl)) {
     val result: Future[Option[Crawl]] = db.run(crawls.filter(_.id === params("crawlId").toInt).result.headOption)
     resultOption(result, ifNotFoundMessage)
   }
 
-  get("/:crawlId/participants") {
+  get("/:crawlId/participants", operation(getCrawlParticipants)) {
     val query = for {
       c <- crawls if c.id === params("crawlId").toInt
       p <- crawlParticipants if c.id === p.crawlId
@@ -44,4 +45,16 @@ class CrawlController(db: Database) extends ScalatraServlet
     Result(404, "not valid endpoint")
   }
 
+}
+
+trait CrawlControllerSwaggerDef extends SwaggerSupport {
+  protected val applicationDescription = "Crawl RESTful API"
+
+  val getCrawl = apiOperation[Crawl]("getCrawl")
+    .parameter(queryParam[Int]("crawlId").description("id for crawl"))
+    .summary("gets a crawl by given id")
+
+  val getCrawlParticipants = apiOperation[Participant]("getParticipants").parameter(queryParam[Int]("crawlId")
+    .description("id for crawl"))
+    .summary("gets all participants of a crawl")
 }

--- a/src/main/scala/io/pubcrawler/stout/controllers/ProfileController.scala
+++ b/src/main/scala/io/pubcrawler/stout/controllers/ProfileController.scala
@@ -5,7 +5,7 @@ import io.pubcrawler.stout.db.{TableDefinitions, User}
 import io.pubcrawler.stout.models.Result
 import io.pubcrawler.stout.util.{JsonFormat, UtilAsync}
 import org.scalatra.json._
-import org.scalatra.swagger.{Api, Swagger, SwaggerEngine, SwaggerSupport}
+import org.scalatra.swagger.{Swagger, SwaggerSupport}
 import org.scalatra.{FutureSupport, ScalatraServlet}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -14,20 +14,29 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 
-class ProfileController(db: Database, implicit val swagger: Swagger) extends ScalatraServlet
-  with JacksonJsonSupport with FutureSupport with ProfileControllerSwaggerDef with TableDefinitions with JsonFormat with UtilAsync {
+class ProfileController(implicit val db: Database, implicit val swagger: Swagger) extends ScalatraServlet
+  with JacksonJsonSupport with FutureSupport with SwaggerSupport with TableDefinitions with JsonFormat with UtilAsync {
   protected implicit val timeout = new Timeout(2.seconds)
 
   private val ifNotFoundMessage: String = "user not found"
+  override protected def applicationDescription: String = "Stout Profile API"
 
   before() {
     contentType = formats("json")
   }
 
+  val getUser = apiOperation[User]("getUser")
+    .parameters(pathParam[String]("username").description("username for user to lookup"))
+    .summary("gets user by given username")
+
   get("/:username", operation(getUser)) {
     val result: Future[Option[User]] = db.run(users.filter(_.username === params("username")).result.headOption)
     resultOption(result, ifNotFoundMessage)
   }
+
+  val getUserByEmail = apiOperation[User]("getUserByEmail")
+    .parameters(pathParam[String]("email").description("email for user"))
+    .summary("gets user with given email")
 
   get("/email/:email", operation(getUserByEmail)) {
     val result: Future[Option[User]] = db.run(users.filter(_.email === params("email")).result.headOption)
@@ -35,19 +44,7 @@ class ProfileController(db: Database, implicit val swagger: Swagger) extends Sca
   }
 
   notFound {
-    Result(404, "not valid endpoint")
+    Result(404, "not a valid endpoint")
   }
 
-}
-
-trait ProfileControllerSwaggerDef extends SwaggerSupport {
-  protected val applicationDescription = "Profile RESTful API"
-
-  val getUser = apiOperation[User]("getUser")
-    .parameter(queryParam[String]("username").description("username for user to lookup"))
-    .summary("gets user by given username")
-
-  val getUserByEmail = apiOperation[User]("getUserByEmail")
-    .parameter(queryParam[String]("email").description("email for user"))
-    .summary("gets user with given email")
 }

--- a/src/main/scala/io/pubcrawler/stout/controllers/ProfileController.scala
+++ b/src/main/scala/io/pubcrawler/stout/controllers/ProfileController.scala
@@ -5,6 +5,7 @@ import io.pubcrawler.stout.db.{TableDefinitions, User}
 import io.pubcrawler.stout.models.Result
 import io.pubcrawler.stout.util.{JsonFormat, UtilAsync}
 import org.scalatra.json._
+import org.scalatra.swagger.{Api, Swagger, SwaggerEngine, SwaggerSupport}
 import org.scalatra.{FutureSupport, ScalatraServlet}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -13,8 +14,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 
-class ProfileController(db: Database) extends ScalatraServlet
-  with JacksonJsonSupport with FutureSupport with TableDefinitions with JsonFormat with UtilAsync {
+class ProfileController(db: Database, implicit val swagger: Swagger) extends ScalatraServlet
+  with JacksonJsonSupport with FutureSupport with ProfileControllerSwaggerDef with TableDefinitions with JsonFormat with UtilAsync {
   protected implicit val timeout = new Timeout(2.seconds)
 
   private val ifNotFoundMessage: String = "user not found"
@@ -23,12 +24,12 @@ class ProfileController(db: Database) extends ScalatraServlet
     contentType = formats("json")
   }
 
-  get("/:username") {
+  get("/:username", operation(getUser)) {
     val result: Future[Option[User]] = db.run(users.filter(_.username === params("username")).result.headOption)
     resultOption(result, ifNotFoundMessage)
   }
 
-  get("/email/:email") {
+  get("/email/:email", operation(getUserByEmail)) {
     val result: Future[Option[User]] = db.run(users.filter(_.email === params("email")).result.headOption)
     resultOption(result)
   }
@@ -37,4 +38,16 @@ class ProfileController(db: Database) extends ScalatraServlet
     Result(404, "not valid endpoint")
   }
 
+}
+
+trait ProfileControllerSwaggerDef extends SwaggerSupport {
+  protected val applicationDescription = "Profile RESTful API"
+
+  val getUser = apiOperation[User]("getUser")
+    .parameter(queryParam[String]("username").description("username for user to lookup"))
+    .summary("gets user by given username")
+
+  val getUserByEmail = apiOperation[User]("getUserByEmail")
+    .parameter(queryParam[String]("email").description("email for user"))
+    .summary("gets user with given email")
 }

--- a/src/main/scala/io/pubcrawler/stout/controllers/SwaggerController.scala
+++ b/src/main/scala/io/pubcrawler/stout/controllers/SwaggerController.scala
@@ -1,0 +1,17 @@
+package io.pubcrawler.stout.controllers
+
+import org.scalatra.ScalatraServlet
+import org.scalatra.swagger.{ApiInfo, JacksonSwaggerBase, Swagger}
+
+class SwaggerController(implicit val swagger: Swagger) extends ScalatraServlet with JacksonSwaggerBase
+
+object StoutApiInfo extends ApiInfo(
+  title = "The Stout API",
+  description = "Swagger docs for the Stout API",
+  termsOfServiceUrl = "https://github.com/Pubcrawler",
+  contact = "apiteam@pubcrawler.io",
+  license = "license",
+  licenseUrl = "licenseUrl"
+)
+
+class StoutSwagger extends Swagger(Swagger.SpecVersion, "1.0.0", StoutApiInfo)

--- a/src/main/scala/io/pubcrawler/stout/db/DbConnection.scala
+++ b/src/main/scala/io/pubcrawler/stout/db/DbConnection.scala
@@ -4,5 +4,5 @@ import slick.jdbc.JdbcBackend.Database
 
 
 trait DbConnection {
-  val db: Database = Database.forConfig("postgres")
+  implicit val db: Database = Database.forConfig("postgres")
 }

--- a/src/main/scala/io/pubcrawler/stout/db/TableDefinitions.scala
+++ b/src/main/scala/io/pubcrawler/stout/db/TableDefinitions.scala
@@ -11,7 +11,7 @@ trait TableDefinitions extends TableMappers {
     def id = column[Int]("user_id", O.PrimaryKey, O.AutoInc)
     def username = column[String]("username")
     def birthdate = column[Option[LocalDate]]("birthdate")
-    def gender = column[Gender.Gender]("gender")
+    def gender = column[Char]("gender")
     def email = column[String]("email")
     def facebookId = column[Int]("facebook_id")
     def * = (id.?, username, birthdate, gender, email, facebookId) <> (User.tupled, User.unapply)
@@ -50,7 +50,7 @@ trait TableDefinitions extends TableMappers {
   class CrawlParticipantTable(tag: Tag) extends Table[CrawlParticipant](tag, "crawl_participants") {
     def crawlId = column[Int]("crawl_id")
     def userId = column[Int]("user_id")
-    def status = column[Status.Status]("status")
+    def status = column[Char]("status")
     def * = (crawlId, userId, status) <> (CrawlParticipant.tupled, CrawlParticipant.unapply)
 
     def crawl = foreignKey("crawl_participants_crawl_id_fkey", crawlId, crawls)(_.id)

--- a/src/main/scala/io/pubcrawler/stout/db/TableMappers.scala
+++ b/src/main/scala/io/pubcrawler/stout/db/TableMappers.scala
@@ -7,10 +7,6 @@ import slick.jdbc.PostgresProfile.api._
 
 trait TableMappers {
 
-  implicit val genderMapper = MappedColumnType.base[Gender.Gender, String](e => e.toString, s => Gender.withName(s))
-
-  implicit val statusMapper = MappedColumnType.base[Status.Status, String](e => e.toString, s => Status.withName(s))
-
   implicit val zonedDateTimeMapper = MappedColumnType.base[LocalDateTime, Timestamp](
     ldt => Timestamp.from(ldt.toInstant(ZoneOffset.UTC)),
     t => LocalDateTime.from(t.toLocalDateTime)

--- a/src/main/scala/io/pubcrawler/stout/db/Types.scala
+++ b/src/main/scala/io/pubcrawler/stout/db/Types.scala
@@ -2,28 +2,32 @@ package io.pubcrawler.stout.db
 
 import java.time.{LocalDate, LocalDateTime}
 
-
-object Gender extends Enumeration {
-  type Gender = Value
-  val M = Value("M") // Male
-  val F = Value("F") // Female
-  val O = Value("O") // Other
-}
-
-object Status extends Enumeration {
-  type Status = Value
-  val A = Value('A') // Accepted
-  val M = Value('M') // Maybe
-  val D = Value('D') // Declined
-}
-
-case class User(id: Option[Int], username: String, birthdate: Option[LocalDate], gender: Gender.Gender, email: String, facebookId: Int)
+/**
+  * @param id
+  * @param username
+  * @param birthdate
+  * @param gender Gender can be one of the following:
+  *               F - Female
+  *               M - Male
+  *               O - Other
+  * @param email
+  * @param facebookId
+  */
+case class User(id: Option[Int], username: String, birthdate: Option[LocalDate], gender: Char, email: String, facebookId: Int)
 
 case class Route(id: Option[Int], ownerId: Int)
 
 case class Crawl(id: Option[Int], title: String, ownerId: Int, routeId: Int, dateTime: LocalDateTime, address: String, city: String, lat: Double, lng: Double, radius: Float, description: String)
 
-case class CrawlParticipant(crawlId: Int, userId: Int, status: Status.Status)
+/**
+  * @param crawlId
+  * @param userId
+  * @param status Status can be one of the following:
+  *               A - Accepted
+  *               D - Declined
+  *               M - Maybe
+  */
+case class CrawlParticipant(crawlId: Int, userId: Int, status: Char)
 
 case class RouteStop(routeId: Int, stopId: Int, order: Int)
 

--- a/src/main/scala/io/pubcrawler/stout/models/Participant.scala
+++ b/src/main/scala/io/pubcrawler/stout/models/Participant.scala
@@ -1,5 +1,3 @@
 package io.pubcrawler.stout.models
 
-import io.pubcrawler.stout.db.Status
-
-case class Participant(username: String, status: Status.Status, userId: Int)
+case class Participant(username: String, status: Char, userId: Int)

--- a/src/main/scala/io/pubcrawler/stout/swagger/ApiDocs.scala
+++ b/src/main/scala/io/pubcrawler/stout/swagger/ApiDocs.scala
@@ -1,0 +1,8 @@
+package io.pubcrawler.stout.swagger
+
+import org.scalatra.ScalatraServlet
+import org.scalatra.swagger.{JacksonSwaggerBase, Swagger}
+
+
+class ApiDocs(implicit val swagger: Swagger) extends ScalatraServlet with JacksonSwaggerBase
+

--- a/src/main/scala/io/pubcrawler/stout/swagger/StoutSwagger.scala
+++ b/src/main/scala/io/pubcrawler/stout/swagger/StoutSwagger.scala
@@ -11,5 +11,5 @@ object StoutApiInfo extends ApiInfo(
   licenseUrl = "licenseUrl"
 )
 
-class StoutSwagger extends Swagger("2.0", "0.0.1", StoutApiInfo)
+class StoutSwagger extends Swagger(Swagger.SpecVersion, "0.0.1", StoutApiInfo)
 

--- a/src/main/scala/io/pubcrawler/stout/swagger/StoutSwagger.scala
+++ b/src/main/scala/io/pubcrawler/stout/swagger/StoutSwagger.scala
@@ -1,0 +1,15 @@
+package io.pubcrawler.stout.swagger
+
+import org.scalatra.swagger.{ApiInfo, Swagger}
+
+object StoutApiInfo extends ApiInfo(
+  title = "Stout RESTful API",
+  description = "Swagger documentation for Stout REST API",
+  termsOfServiceUrl = "http://localhost:8080",
+  contact = "apiteam@pubcrawler.io",
+  license = "license",
+  licenseUrl = "licenseUrl"
+)
+
+class StoutSwagger extends Swagger("2.0", "0.0.1", StoutApiInfo)
+

--- a/src/main/scala/io/pubcrawler/stout/util/JsonFormat.scala
+++ b/src/main/scala/io/pubcrawler/stout/util/JsonFormat.scala
@@ -4,19 +4,18 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.{TemporalAccessor, TemporalQuery}
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 
-import io.pubcrawler.stout.db.{Gender, Status}
 import org.json4s.JsonAST.JString
-import org.json4s.ext.EnumNameSerializer
 import org.json4s.{CustomSerializer, DefaultFormats, Formats}
 
 
 trait JsonFormat {
-  implicit lazy val jsonFormats: Formats = DefaultFormats ++ JavaTimeSerializers.defaults ++ EnumNameSerializers.defaults
+  implicit lazy val jsonFormats: Formats = DefaultFormats ++ JavaTimeSerializers.defaults + CharSerializer
 }
 
-object EnumNameSerializers {
-  val defaults = new EnumNameSerializer(Gender) :: new EnumNameSerializer(Status) :: Nil
-}
+object CharSerializer extends CustomSerializer[Char](format => (
+  { case JString(x) if x.length == 1 => x.head },
+  { case x: Char => JString(x.toString) }
+))
 
 object JavaTimeSerializers {
   // Borrowed from https://github.com/meetup/json4s-java-time/../JavaTimeSerializers.scala


### PR DESCRIPTION
Currently yields null-point exception due to enums in User and CrawlParticipants.

An alternative might be to remove enum-values and define type Status and Gender to be chars.

We won't have the same 'safety', but if we introduce validation rules for user submitted data anyway, then we won't need it.